### PR TITLE
Improved index layout and linked cards to card pages

### DIFF
--- a/app/assets/stylesheets/components/_images.scss
+++ b/app/assets/stylesheets/components/_images.scss
@@ -1,0 +1,6 @@
+.card_images {
+  width: 95%;
+  border-radius: 2%;
+  display: block;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,3 +3,4 @@
 @import "avatar";
 @import "form_legend_clear";
 @import "navbar";
+@import "images";

--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -55,3 +55,8 @@
   z-index: 1;
   top: 0;
 }
+
+a {
+  text-decoration: none;
+  color: black;
+}

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -1,13 +1,25 @@
-<h1>Pokemon Cards</h1>
-
-<ul class="list-unstyled">
-  <% @cards.each do |card| %>
-    <li><h3><%=card.title%></h3></li>
-    <li><strong>Details:</strong></li>
-    <li><%=card.description%></li>
-    <br>
-    <li><strong>price:</strong> <%=card.ppd%> € per day</li>
-    <li><strong>vendor:</strong> <%=card.user.username%></li>
-    <br>
-  <% end %>
-</ul>
+<body class="bg-light">
+  <h2 class="text-center my-4"><strong>Pokemon Cards</strong></h2>
+  <div class="container">
+    <div class="row">
+      <% @cards.each do |card| %>
+        <div class="col-md-3 mb-4">
+          <%= link_to card_path(card) do %>
+            <div class="card h-100 bg-white">
+              <div class="card-body">
+                <img class="card_images" src="https://i.etsystatic.com/9235907/r/il/1c51e7/1222367197/il_fullxfull.1222367197_7j22.jpg" alt="Pikachu">
+                <div>
+                  <h3 class="card-title text-center my-2"><strong><%= card.title %></strong></h3>
+                  <p class="card-text"><strong>Details:</strong> <%= card.description %></p>
+                  <p class="card-text"><strong>Price:</strong> <strong><%= card.ppd %>€</strong> per day</p>
+                  <p class="card-text"><strong>Vendor:</strong> <%= card.user.username %></p>
+            <% end %>
+                  <button class="btn btn-dark mt-2">Rent</button>
+                </div>
+              </div>
+            </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</body>


### PR DESCRIPTION
Created a nice layout for the index page and linked the cards to their individual show pages.
I mainly used bootstrap for the design - we can improve this later on. I also added the same image for each card just to work on the layout. We'll soon need to use cloudinary and the PokeAPI to have better/more realistic data on our pages!